### PR TITLE
Add launching a save from the CLI

### DIFF
--- a/bin/kano-draw
+++ b/bin/kano-draw
@@ -42,5 +42,8 @@ SERVER_PROC.daemon = True
 SERVER_PROC.start()
 
 # Init the web app
-DRAW = Draw()
+if len(sys.argv) > 1:
+    DRAW = Draw(load_path=sys.argv[1])
+else:
+    DRAW = Draw()
 DRAW.run()

--- a/debian/kano-draw.install
+++ b/debian/kano-draw.install
@@ -3,6 +3,7 @@ kano_draw /usr/lib/python2.7/dist-packages
 www/* /usr/share/kano-draw
 
 kdesktop/Draw.lnk usr/share/kano-desktop/kdesk/kdesktop/
+kdesktop/kano-draw.xml /usr/share/mime/packages/
 icon/kano-draw.png usr/share/icons/Kano/88x88/apps
 icon/kano-draw-hover.png usr/share/icons/Kano/88x88/apps
 icon/kano-draw.app usr/share/applications

--- a/kano_draw/draw.py
+++ b/kano_draw/draw.py
@@ -1,10 +1,14 @@
 from kano.webapp import WebApp
 
 class Draw(WebApp):
-    def __init__(self):
+    def __init__(self, load_path=''):
         super(Draw, self).__init__()
 
         self._index = "http://localhost:8000"
+        if load_path:
+            self._index = '{}/localLoad/{}'.format(self._index,
+                                                   load_path.strip('/'))
+
         self._title = "Draw"
         self._app_icon = '/usr/share/icons/Kano/88x88/apps/kano-draw.png'
 

--- a/kano_draw/server.py
+++ b/kano_draw/server.py
@@ -76,8 +76,11 @@ server_logger.setLevel(logging.ERROR)
 
 
 @server.route('/')
-def root():
+# Redirect a localLoad back to index for routing in Angular
+@server.route('/localLoad/<path:path>')
+def root(path=None):
     return server.send_static_file('index.html')
+
 
 @server.route('/<path:path>')
 def static_proxy(path):
@@ -92,6 +95,12 @@ def save_challenge(filename):
     _save(data)
 
     return ''
+
+@server.route("/challenge/local/<path:path>", methods=['GET'])
+def load_challenge(path):
+    directory, filename = os.path.split(path)
+
+    return send_from_directory('/{}'.format(directory), filename, as_attachment=True)
 
 @server.route("/challenge/local/wallpaper/<path:filename>", methods=['POST'])
 def save_wallpaper(filename):

--- a/kdesktop/kano-draw.xml
+++ b/kdesktop/kano-draw.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<mime-info xmlns='http://www.freedesktop.org/standards/shared-mime-info'>
+    <mime-type type="application/x-kano-draw">
+        <comment>Kano Draw Drawing</comment>
+        <glob pattern="*.draw"/>
+    </mime-type>
+</mime-info>

--- a/lib/api/offline/challenge-io.js
+++ b/lib/api/offline/challenge-io.js
@@ -26,6 +26,14 @@ module.exports = {
             cb(res.body);
         }, notify.failure);
     },
+    localLoad: function(path, cb) {
+        api.challenge.localLoad({
+            path       : path
+        })
+        .then(function (res) {
+            cb(res.body);
+        }, notify.failure);
+    },
     saveWallpaper: function(filename, image_1024, image_4_3, image_16_9) {
         api.challenge.saveWallpaper({
             filename   : filename,

--- a/lib/api/offline/local-api.js
+++ b/lib/api/offline/local-api.js
@@ -25,6 +25,12 @@ apiService.add('challenge.share', {
     params : [ 'filename', 'description', 'code', 'image' ]
 });
 
+apiService.add('challenge.localLoad', {
+    method : 'get',
+    route  : '/challenge/local/:path',
+    params : ['filename']
+});
+
 apiService.add('progress.load', {
     method : 'get',
     route  : '/progress'

--- a/lib/controller/local-launch.js
+++ b/lib/controller/local-launch.js
@@ -1,0 +1,14 @@
+var app = require('../app'),
+    api = require('../api');
+
+app.controller('LocalLaunchController', function ($scope, $routeParams, $location) {
+    $scope.path = $routeParams.path || null;
+
+    api.challengeIO.localLoad($scope.path, function (fileData) {
+        localStorage.playgroundCode = fileData;
+        $scope.$apply(function() {
+            $location.path('/playground');
+        });
+
+    });
+});

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,6 +17,7 @@ require('./controller/challenge-menu-item');
 require('./controller/export');
 require('./controller/loadDialog');
 require('./controller/share');
+require('./controller/local-launch');
 require('./controller/examples');
 
 // Directives

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -7,5 +7,6 @@ app.config(function ($routeProvider) {
     .when('/level/:id', { templateUrl: '/level.html', controller: 'LevelController' })
     .when('/playground', { templateUrl: '/playground.html', controller: 'PlaygroundController' })
     .when('/share/:id', { templateUrl: '/share.html', controller: 'ShareController' })
+    .when('/localLoad/:path*', { templateUrl: '/share.html', controller: 'LocalLaunchController' })
     .otherwise({ redirectTo: '/' });
 });


### PR DESCRIPTION
KanoComputing/peldins#1511
KanoComputing/peldins#1545
This allows launching of Kano Draw and opening a save at the same time
by using `kano-draw /path/to/save`. This has ramifications for both
launching shares from the Kano Profile GUI and also behaviour when
double clicking on a `.draw` file.

This implementation redirects the webapp to `/localLoad/path/to/save`
which in turn loads the file from the local server and redirects to the
playground in order to be able to view it. The behaviour is similar to
when launching an online share directly from the URL but because this
online functionality is already deployed and a slightly different case,
this solution does not integrate with it.