### PR TITLE
Add MIME type information to .app file

### DIFF
--- a/icon/kano-draw.app
+++ b/icon/kano-draw.app
@@ -8,6 +8,7 @@
     "colour": "#7BAA64",
 
     "categories": ["code"],
+    "mime_type": "application/x-kano-draw",
 
     "packages": [],
     "dependencies": ["kano-draw"],


### PR DESCRIPTION
KanoComputing/peldins#1511
Adds MIME type information to the `.app` file so that the autogenerated
`.desktop` file contains the MimeType field. To be used in conjunction
with
KanoComputing/kano-apps/commit/d2e3e28e44ec4f92a586fdc0718aca1a741e6d2f