### PR TITLE
Fix exporting wallpapers

### DIFF
--- a/lib/controller/export.js
+++ b/lib/controller/export.js
@@ -104,7 +104,7 @@ app.controller('ExportController', function($scope, $window, $rootScope) {
     $scope.exportWallpaper = function() {
         var wallpapers = getWallpapers();
 
-        api.challengeIO.local.saveWallpaper(
+        api.challengeIO.saveWallpaper(
             $scope.filename,
             wallpapers['1024'],
             wallpapers['4-3'],


### PR DESCRIPTION
Exporting wallpaper functionality was broken by renaming in commit
KanoComputing/kano-draw/commit/b333a3feace048163bbd9403bd3669c8b7c761d2.
Fix calls to this function.