### PR TITLE
Wallpaper: Ensure that wallpapers have backgrounds

### DIFF
--- a/lib/directive/export-modal.js
+++ b/lib/directive/export-modal.js
@@ -255,6 +255,12 @@ app.directive('exportModal', function ($rootScope) {
                     tempCanvas.height = size.height;
 
                     tempCtx.scale(scaleFactor, scaleFactor);
+
+                    // toDataURL() retains alpha, so paint a white bg
+                    tempCtx.rect(0, 0, size.width, size.height);
+                    tempCtx.fillStyle = 'white';
+                    tempCtx.fill();
+
                     tempCtx.drawImage(canvas, offset.x, offset.y);
                 };
 


### PR DESCRIPTION
KanoComputing/peldins#1787
Currently, when exporting a wallpaper, the alpha from the created image
is retained which means that there is no background. This is a problem
because the canvas upon which the drawing is designed has a white
background, but when used as a wallpaper, the default background is
black. Fix this by artificially drawing a white background when exporting