### PR TITLE
Added support for grouping challenges KanoComputing/engage#17

### DIFF
--- a/lib/api/online/progress.js
+++ b/lib/api/online/progress.js
@@ -1,10 +1,20 @@
 var sdk = require('kano-world-sdk');
 
-function save(challengeNo, callback) {
-    localStorage.challenge = challengeNo;
+function save(challengeNo, groupName, callback) {
+    var data = { groups: {} };
+
+    if (groupName) {
+        data.groups[groupName] = {};
+        data.groups[groupName][challengeNo] = true;
+        localStorage.groups = data.groups;
+    }
+    else {
+        data.challenge = challengeNo;
+        localStorage.challenge = challengeNo;
+    }
 
     if (sdk.auth.getUser()) {
-        sdk.appStorage.set('kano-draw', { challenge: challengeNo }, function () {
+        sdk.appStorage.set('kano-draw', data, function () {
             callback(0);
         });
     } else {
@@ -24,11 +34,10 @@ function load(callback) {
             if (data && data.challenge && data.challenge > challenge) {
                 challenge = data.challenge;
             }
-
-            callback(challenge);
+            callback(challenge, data.groups);
         });
     } else {
-        callback(challenge);
+        callback(challenge, localStorage.groups);
     }
 }
 

--- a/lib/api/online/progress.js
+++ b/lib/api/online/progress.js
@@ -5,7 +5,7 @@ function save(challengeNo, groupName, callback) {
 
     if (groupName) {
         data.groups[groupName] = {};
-        data.groups[groupName][challengeNo] = true;
+        data.groups[groupName].challengeNo = challengeNo;
         localStorage.groups = data.groups;
     }
     else {

--- a/lib/app.js
+++ b/lib/app.js
@@ -96,7 +96,7 @@ app.run(function ($rootScope, $window) {
             });
             $rootScope.progress.groups = {};
             $rootScope.progress.groups[groupName] = {};
-            $rootScope.progress.groups[groupName][challengeNo] = true;
+            $rootScope.progress.groups[groupName].challengeNo = challengeNo;
         }
         else if (challengeNo > $rootScope.progress.challengeNo) {
             api.progress.save(challengeNo, null, function(xpGain) {

--- a/lib/app.js
+++ b/lib/app.js
@@ -15,11 +15,9 @@ var app = angular.module('draw', [ 'ngRoute' ]);
 
 // Configure app
 app.config(function ($locationProvider) {
-
     if (window.history && window.history.pushState) {
         $locationProvider.html5Mode(true);
     }
-
 });
 
 // Run app
@@ -29,6 +27,7 @@ app.run(function ($rootScope, $window) {
     // Define global app initial values
     $rootScope.challenges = challenges;
     $rootScope.progress = {};
+    $rootScope.progress.groups = {};
     $rootScope.offline = config.OFFLINE;
     $rootScope.loggedIn = false;
     $rootScope.user = null;
@@ -38,6 +37,7 @@ app.run(function ($rootScope, $window) {
 
     // Prefill progress from localStorage
     $rootScope.progress.challengeNo = parseInt(localStorage.challenge || 0, 10);
+    $rootScope.progress.groups = localStorage.groups || {};
 
     // Initialised auth state
     auth.init(function () {
@@ -45,8 +45,9 @@ app.run(function ($rootScope, $window) {
         $rootScope.user = auth.getUser();
 
         // Load progress
-        api.progress.load(function (challengeNo) {
+        api.progress.load(function (challengeNo, groups) {
             $rootScope.progress.challengeNo = challengeNo || 1;
+            $rootScope.progress.groups = groups;
             $rootScope.$apply();
         });
     });
@@ -87,22 +88,27 @@ app.run(function ($rootScope, $window) {
      * @param {Number} challengeNo
      * @return void
      */
-    $rootScope.updateProgress = function (challengeNo) {
-        if (challengeNo > $rootScope.progress.challengeNo) {
-
-            api.progress.save(challengeNo, function(xpGain) {
+    $rootScope.updateProgress = function (challengeNo, groupName) {
+        if (groupName) {
+            api.progress.save(challengeNo, groupName, function(xpGain) {
                 $rootScope.xpGain = xpGain;
                 $rootScope.$apply();
             });
-
+            $rootScope.progress.groups = {};
+            $rootScope.progress.groups[groupName] = {};
+            $rootScope.progress.groups[groupName][challengeNo] = true;
+        }
+        else if (challengeNo > $rootScope.progress.challengeNo) {
+            api.progress.save(challengeNo, null, function(xpGain) {
+                $rootScope.xpGain = xpGain;
+                $rootScope.$apply();
+            });
             $rootScope.progress.challengeNo = challengeNo;
             $rootScope.$apply();
 
         } else {
-
             $rootScope.xpGain = 0;
             $rootScope.$apply();
-
         }
     };
 

--- a/lib/filter/string.js
+++ b/lib/filter/string.js
@@ -7,9 +7,9 @@
 var app = require('../app');
 
 /*
- * Pads input number to reach given number of digits
+ * Converts the first letter of a string to uppercase
  *
- * @param {Number} value
+ * @param {String} str
  * @return {String}
  */
 app.filter('upperfirst', function () {


### PR DESCRIPTION
@andela-ladenusi please can you review these changes.

Note these changes will allow you to track completion of individual challenges in a new grouped concept.

Each time a user completes a challenge in the Summer Camp, you can save progress by calling
$rootScope.updateProgress(challengeNo, "summer_camp_2015");

For the calendar, you can check $rootScope.progress.groups.summer_camp_2015[challengeNo] to see if the user has completed that challenge or not.  Of course, we can write some wrapper functions to simplify the long-windedness of this call :)