### PR TITLE
Tracking: Add challenge attempts and completion

### DIFF
--- a/lib/api/online/auth.js
+++ b/lib/api/online/auth.js
@@ -1,4 +1,5 @@
-var sdk = require('kano-world-sdk');
+var sdk = require('kano-world-sdk'),
+    analytics = require('../../core/analytics');
 
 /*
  * Initialise Kano World SDK with auth
@@ -7,7 +8,13 @@ var sdk = require('kano-world-sdk');
  * @return void
  */
 function init(callback) {
-    sdk.init(callback);
+    sdk.init(function(err, user) {
+        if (!err) {
+            analytics.identify(user);
+        }
+
+        callback(err, user);
+    });
 }
 
 module.exports = {

--- a/lib/controller/challenge.js
+++ b/lib/controller/challenge.js
@@ -7,7 +7,8 @@ var app = require('../app'),
     session = require('../language/session'),
     sound = require('../core/sound'),
     config = require('../core/config'),
-    api = require('../api');
+    api = require('../api'),
+    analytics = require('../core/analytics');
 
 /*
  * Challenge Controller
@@ -49,6 +50,9 @@ app.controller('ChallengeController', function ($scope, $routeParams, $window, $
     setStep(0);
     $scope.started = true;
     $scope.animationClass = '';
+    analytics.track('Started Challenge ' + $scope.id, {
+        category: 'Started Challenge'
+    });
 
     $scope.$watch('step', function (step) {
         $scope.hint = $scope.content.steps[step] ? $scope.content.steps[step].hint : null;
@@ -152,6 +156,9 @@ app.controller('ChallengeController', function ($scope, $routeParams, $window, $
             }
 
             if (session.steps && finished && !$scope.completed) {
+                analytics.track('Completed Challenge ' + $scope.id, {
+                    category: 'Completed Challenge'
+                });
                 $scope.completed = true;
 
                 if ($scope.fatherDay) {

--- a/lib/controller/challenges.js
+++ b/lib/controller/challenges.js
@@ -1,7 +1,8 @@
 var app = require('../app'),
     challenges = require('../challenges/index'),
     api = require('../api'),
-    config = require('../core/config');
+    config = require('../core/config'),
+    analytics = require('../core/analytics');
 
 /*
  * Challenges Controller
@@ -98,6 +99,9 @@ app.controller('ChallengesController', function ($scope, $rootScope) {
     $scope.selectChallenge = function (challenge) {
         if ($scope.isLocked(challenge.index)) { return; }
 
+        analytics.track('Viewed Challenge ' + (challenge.index + 1), {
+            category : 'Viewed Challenge'
+        });
         $scope.selectedChallenge = challenge;
     };
 

--- a/lib/controller/summer-camp-challenge.js
+++ b/lib/controller/summer-camp-challenge.js
@@ -6,7 +6,8 @@ var app = require('../app'),
     language = require('../language/index'),
     session = require('../language/session'),
     sound = require('../core/sound'),
-    config = require('../core/config');
+    config = require('../core/config'),
+    analytics = require('../core/analytics');
 
 /*
  * Challenge Controller
@@ -38,6 +39,9 @@ app.controller('SummerCampChallengeController', function ($scope, $routeParams, 
     setStep(0);
     $scope.started = true;
     $scope.animationClass = '';
+    analytics.track('Started Challenge ' + $scope.id, {
+        category: 'Started Summer Camp Challenge'
+    });
 
 
     $scope.$watch('step', function (step) {
@@ -116,6 +120,9 @@ app.controller('SummerCampChallengeController', function ($scope, $routeParams, 
             }
 
             if (session.steps && finished && !$scope.completed) {
+                analytics.track('Completed Challenge ' + $scope.id, {
+                    category: 'Completed Summer Camp Challenge'
+                });
                 $scope.completed = true;
                 
                 api.progress.trackLinesOfCode($scope.challenge.code.split('\n').length);

--- a/lib/controller/summer-camp.js
+++ b/lib/controller/summer-camp.js
@@ -4,8 +4,9 @@ var app = require('../app'),
     config = require('../core/config'),
     moment = require('moment'),
     countDownInterval,
-    startDate = moment('10-08-2015 06:00:00', 'DD-MM-YYYY HH:mm:ss');
-    
+    startDate = moment('10-08-2015 06:00:00', 'DD-MM-YYYY HH:mm:ss'),
+    analytics = require('../core/analytics');
+
 
 /*
  * Summer Challenges Controller
@@ -96,6 +97,9 @@ app.controller('SummerCampController', function ($interval, $scope, $rootScope, 
         $scope.selectedSummerChallengeObj = challenges[selectedChallenge];
 
         $scope.isFutureChallenge = (day > currentDayIndex()) ? true : false;
+        analytics.track('Viewed Challenge ' + day, {
+            category : 'Viewed Summer Camp Challenge'
+        });
     };
 
     /*

--- a/lib/core/analytics.js
+++ b/lib/core/analytics.js
@@ -1,10 +1,11 @@
-var config = require('../core/config'),
+var config = require('./config'),
     analytics = window.analytics;
 
 /*
  * Analytics module
  *
  * Wrapper to Segment.io analytics
+ * More documentation at: https://segment.com/docs/libraries/analytics.js
  */
 
 var enabled = config.SEGMENTIO_ID && !config.OFFLINE && analytics;
@@ -18,7 +19,7 @@ var enabled = config.SEGMENTIO_ID && !config.OFFLINE && analytics;
 exports.init = function () {
     if (!enabled) { return; }
 
-    analytics.load(config.SEGMENTIO_ID);
+    window.analytics.load(config.SEGMENTIO_ID);
 };
 
 /*
@@ -30,5 +31,41 @@ exports.init = function () {
 exports.page = function (pageId) {
     if (!enabled) { return; }
 
-    analytics.page(pageId);
+    window.analytics.page(pageId);
+};
+
+/*
+ * Tie a user to the tracked data
+ *
+ *
+ * @param {String}   [userId]   - The database ID for the user. If as yet
+ *                                unknown, you can omit and just record traits
+ * @param {Object}   [traits]   - Dictionary of known traits of the user, e.g.
+ *                                email or name
+ * @param {Object}   [options]  - Dictionary to enable or disable specific
+ *                                integrations for the call
+ * @param {Function} [callback] - Callback called after a short timeout
+ * @return void
+ */
+exports.identify = function (userId, traits, options, callback) {
+    if (!enabled) { return; }
+
+    window.analytics.identify(userId, traits, options, callback);
+};
+
+/*
+ * Record actions that a user performs
+ *
+ * @param {String}   event        - Tracked event name, e.g. 'Added to Cart'
+ * @param {Object}   [properties] - Dictionary of event properties, e.g. price,
+ *                                  productType, etc.
+ * @param {Object}   [options]    - Dictionary to enable or disable specific
+ *                                  integrations for the call
+ * @param {Function} [callback]   - Callback called after a short timeout
+ * @return void
+ */
+exports.track = function (event, properties, options, callback) {
+    if (!enabled) { return; }
+
+    window.analytics.track(event, properties, options, callback);
 };


### PR DESCRIPTION
KanoComputing/Engage#12
Currently we don't know how many people start or finish a challenge, so
it is difficult to tell where users drop off. Add in tracking of these
events to improve user experience.