### PR TITLE
Summer Camp Tracking: Add UTM source tag to banner

### DIFF
--- a/views/partial/header.jade
+++ b/views/partial/header.jade
@@ -31,7 +31,7 @@ header: .page-width
         li: button.close(ng-click='shutdown()', ng-if='offline'): i.icon-cross
 
 .summercamp
-    a(href="http://www.kano.me/summercamp" class="banner")
+    a(href="http://www.kano.me/summercamp?utm_source=Make%20Art&utm_medium=Banner&utm_campaign=Summer%20Camp" class="banner")
         img(src="/assets/summercamp/logo.png")
         span Free coding challenges:
         |   Every day for three weeks this summer. Enroll now.


### PR DESCRIPTION
In order to accurately track where referrals are coming from, each link
needs to be marked with UTM source tags. Implement this for the Summer
Camp banner's link to the Summer Camp landing page.

cc @arifshanji 