### PR TITLE
Summer Camp Banner: Point the link to the calendar

### DIFF
--- a/views/partial/header.jade
+++ b/views/partial/header.jade
@@ -30,7 +30,7 @@ header: .page-width
         li: button.close(ng-click='shutdown()', ng-if='offline'): i.icon-cross
 
 .summercamp
-    a(href="http://www.kano.me/summercamp?utm_source=Make%20Art&utm_medium=Banner&utm_campaign=Summer%20Camp" class="banner")
+    a(href="/summercamp/calendar?utm_source=Make%20Art&utm_medium=banner&utm_campaign=Summer%20Camp" class="banner")
         img(src="/assets/summercamp/logo.png")
         span Free coding challenges:
         |   Every day for three weeks this summer.  {{summerCampStarted ? "Start now" : "Enroll now"}}.


### PR DESCRIPTION
During the pre-launch period, the banner was used to direct users to the
landing page. Now that the Summer Camp campaign is live, direct users
directly to the challenges rather than the explanation.

cc @arifshanji @alecmolloy 