### PR TITLE
Summer Camp Leaderboard: Remove background colour

### DIFF
--- a/styles/views/summer-camp.styl
+++ b/styles/views/summer-camp.styl
@@ -280,7 +280,6 @@ challenge_icon(img)
 					min-height 145px
 
 	.summercamp-leaderboard
-		background: #5c5951
 		padding: 40px
 		color: #8d887c
 		font-weight: bold


### PR DESCRIPTION
The leaderboard had a background colour set but this is unnecessary
because the colour should just be the same as the page, so remove it.

cc @alecmolloy @arifshanji 