### PR TITLE
Summer Camp Leaderboard: Redraw after receiving data

### DIFF
--- a/lib/controller/summer-camp-leaderboard.js
+++ b/lib/controller/summer-camp-leaderboard.js
@@ -17,6 +17,7 @@ app.controller('SummerCampLeaderboardController', function ($scope, $rootScope) 
         })
         .then(function (res) {
             $scope.leaderboard_entries = res.body;
+            $scope.$apply();
         }, function (res) {
             $scope.showError(res.body);
         })


### PR DESCRIPTION
The Summer Camp leaderboard would occasionally get stuck in a loading
state, even after the API query had returned. This was because the
Angular scope was not marked for update so ensure that it is after the
scope variables are set.

cc @arifshanji 